### PR TITLE
Replace log with logrus

### DIFF
--- a/generated/datasources/transform/decode/role_name.go
+++ b/generated/datasources/transform/decode/role_name.go
@@ -8,7 +8,7 @@ package decode
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/generated/datasources/transform/encode/role_name.go
+++ b/generated/datasources/transform/encode/role_name.go
@@ -8,7 +8,7 @@ package encode
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/generated/resources/transform/alphabet/name.go
+++ b/generated/resources/transform/alphabet/name.go
@@ -8,7 +8,7 @@ package alphabet
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/generated/resources/transform/role/name.go
+++ b/generated/resources/transform/role/name.go
@@ -8,7 +8,7 @@ package role
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/generated/resources/transform/template/name.go
+++ b/generated/resources/transform/template/name.go
@@ -8,7 +8,7 @@ package template
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/generated/resources/transform/transformation/name.go
+++ b/generated/resources/transform/transformation/name.go
@@ -8,7 +8,7 @@ package transformation
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/helper/mutexkv.go
+++ b/helper/mutexkv.go
@@ -4,7 +4,7 @@
 package helper
 
 import (
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 )
 

--- a/helper/transport.go
+++ b/helper/transport.go
@@ -8,7 +8,7 @@ package helper
 import (
 	"bytes"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/http/httputil"
 	"os"

--- a/internal/identity/entity/entity.go
+++ b/internal/identity/entity/entity.go
@@ -6,7 +6,7 @@ package entity
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"

--- a/internal/identity/group/group.go
+++ b/internal/identity/group/group.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/internal/identity/mfa/mfa.go
+++ b/internal/identity/mfa/mfa.go
@@ -6,7 +6,7 @@ package mfa
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"sync"
 

--- a/internal/provider/meta.go
+++ b/internal/provider/meta.go
@@ -6,7 +6,7 @@ package provider
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"os"
 	"strings"

--- a/util/util.go
+++ b/util/util.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"reflect"
 	"regexp"

--- a/vault/auth_mount.go
+++ b/vault/auth_mount.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_identity_entity.go
+++ b/vault/data_identity_entity.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/data_identity_group.go
+++ b/vault/data_identity_group.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/data_identity_oidc_client_creds.go
+++ b/vault/data_identity_oidc_client_creds.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/data_identity_oidc_openid_config.go
+++ b/vault/data_identity_oidc_openid_config.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/data_identity_oidc_public_keys.go
+++ b/vault/data_identity_oidc_public_keys.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/data_source_ad_credentials.go
+++ b/vault/data_source_ad_credentials.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/data_source_approle_auth_backend_role_id.go
+++ b/vault/data_source_approle_auth_backend_role_id.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_aws_access_credentials.go
+++ b/vault/data_source_aws_access_credentials.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/vault/data_source_aws_access_credentials_test.go
+++ b/vault/data_source_aws_access_credentials_test.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"

--- a/vault/data_source_azure_access_credentials.go
+++ b/vault/data_source_azure_access_credentials.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"time"
 

--- a/vault/data_source_gcp_auth_backend_role.go
+++ b/vault/data_source_gcp_auth_backend_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_generic_secret.go
+++ b/vault/data_source_generic_secret.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_kubernetes_auth_backend_config.go
+++ b/vault/data_source_kubernetes_auth_backend_config.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_kubernetes_auth_backend_role.go
+++ b/vault/data_source_kubernetes_auth_backend_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_kv_secret.go
+++ b/vault/data_source_kv_secret.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_kv_secret_v2.go
+++ b/vault/data_source_kv_secret_v2.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/data_source_kv_subkeys_v2.go
+++ b/vault/data_source_kv_subkeys_v2.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/data_source_nomad_credentials.go
+++ b/vault/data_source_nomad_credentials.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/data_source_policy_document.go
+++ b/vault/data_source_policy_document.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sort"
 	"strconv"
 	"strings"

--- a/vault/data_source_raft_autopilot_state.go
+++ b/vault/data_source_raft_autopilot_state.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/kv_helpers.go
+++ b/vault/kv_helpers.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"path"
 	"strings"
 

--- a/vault/password_policy.go
+++ b/vault/password_policy.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/provider.go
+++ b/vault/provider.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"os"
 
 	"github.com/hashicorp/go-multierror"

--- a/vault/resource_ad_secret_backend.go
+++ b/vault/resource_ad_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"

--- a/vault/resource_ad_secret_library.go
+++ b/vault/resource_ad_secret_library.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_ad_secret_roles.go
+++ b/vault/resource_ad_secret_roles.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_alicloud_auth_backend_role.go
+++ b/vault/resource_alicloud_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_approle_auth_backend_login.go
+++ b/vault/resource_approle_auth_backend_login.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_approle_auth_backend_role.go
+++ b/vault/resource_approle_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_approle_auth_backend_role_secret_id.go
+++ b/vault/resource_approle_auth_backend_role_secret_id.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_audit.go
+++ b/vault/resource_audit.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_audit_request_header.go
+++ b/vault/resource_audit_request_header.go
@@ -2,7 +2,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_auth_backend.go
+++ b/vault/resource_auth_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_auth_backend_migrate.go
+++ b/vault/resource_auth_backend_migrate.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/vault/resource_aws_auth_backend_cert.go
+++ b/vault/resource_aws_auth_backend_cert.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_client.go
+++ b/vault/resource_aws_auth_backend_client.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_config_identity.go
+++ b/vault/resource_aws_auth_backend_config_identity.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_identity_whitelist.go
+++ b/vault/resource_aws_auth_backend_identity_whitelist.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_login.go
+++ b/vault/resource_aws_auth_backend_login.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_aws_auth_backend_role.go
+++ b/vault/resource_aws_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_role_tag.go
+++ b/vault/resource_aws_auth_backend_role_tag.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_aws_auth_backend_roletag_blacklist.go
+++ b/vault/resource_aws_auth_backend_roletag_blacklist.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_auth_backend_sts_role.go
+++ b/vault/resource_aws_auth_backend_sts_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_aws_secret_backend.go
+++ b/vault/resource_aws_secret_backend.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_aws_secret_backend_role.go
+++ b/vault/resource_aws_secret_backend_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vault/resource_azure_auth_backend_config.go
+++ b/vault/resource_azure_auth_backend_config.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_azure_auth_backend_role.go
+++ b/vault/resource_azure_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_azure_secret_backend.go
+++ b/vault/resource_azure_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_azure_secret_backend_role.go
+++ b/vault/resource_azure_secret_backend_role.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_cert_auth_backend_role.go
+++ b/vault/resource_cert_auth_backend_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_consul_secret_backend.go
+++ b/vault/resource_consul_secret_backend.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_consul_secret_backend_role.go
+++ b/vault/resource_consul_secret_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_database_secret_backend_connection.go
+++ b/vault/resource_database_secret_backend_connection.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"sort"
 	"strconv"

--- a/vault/resource_database_secret_backend_connection_test.go
+++ b/vault/resource_database_secret_backend_connection_test.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"net/url"
 	"os"

--- a/vault/resource_database_secret_backend_role.go
+++ b/vault/resource_database_secret_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_database_secret_backend_static_role.go
+++ b/vault/resource_database_secret_backend_static_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_database_secrets_mount.go
+++ b/vault/resource_database_secrets_mount.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_gcp_auth_backend.go
+++ b/vault/resource_gcp_auth_backend.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_gcp_auth_backend_role.go
+++ b/vault/resource_gcp_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_gcp_secret_backend.go
+++ b/vault/resource_gcp_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_gcp_secret_impersonated_account.go
+++ b/vault/resource_gcp_secret_impersonated_account.go
@@ -3,7 +3,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_gcp_secret_roleset.go
+++ b/vault/resource_gcp_secret_roleset.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_gcp_secret_static_account.go
+++ b/vault/resource_gcp_secret_static_account.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_generic_endpoint.go
+++ b/vault/resource_generic_endpoint.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_generic_secret.go
+++ b/vault/resource_generic_secret.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"time"
 

--- a/vault/resource_generic_secret_migrate.go
+++ b/vault/resource_generic_secret_migrate.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )

--- a/vault/resource_github_auth_backend.go
+++ b/vault/resource_github_auth_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_github_auth_backend_test.go
+++ b/vault/resource_github_auth_backend_test.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 	"testing"

--- a/vault/resource_github_team.go
+++ b/vault/resource_github_team.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_github_team_test.go
+++ b/vault/resource_github_team_test.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"testing"
 

--- a/vault/resource_github_user.go
+++ b/vault/resource_github_user.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_github_user_test.go
+++ b/vault/resource_github_user_test.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"

--- a/vault/resource_identity_entity.go
+++ b/vault/resource_identity_entity.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_identity_entity_alias.go
+++ b/vault/resource_identity_entity_alias.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_identity_entity_policies.go
+++ b/vault/resource_identity_entity_policies.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_group.go
+++ b/vault/resource_identity_group.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_identity_group_alias.go
+++ b/vault/resource_identity_group_alias.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_group_policies.go
+++ b/vault/resource_identity_group_policies.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc.go
+++ b/vault/resource_identity_oidc.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_assignment.go
+++ b/vault/resource_identity_oidc_assignment.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_client.go
+++ b/vault/resource_identity_oidc_client.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_key.go
+++ b/vault/resource_identity_oidc_key.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_identity_oidc_key_allowed_client_id.go
+++ b/vault/resource_identity_oidc_key_allowed_client_id.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_provider.go
+++ b/vault/resource_identity_oidc_provider.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_role.go
+++ b/vault/resource_identity_oidc_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_identity_oidc_scope.go
+++ b/vault/resource_identity_oidc_scope.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_jwt_auth_backend.go
+++ b/vault/resource_jwt_auth_backend.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_jwt_auth_backend_role.go
+++ b/vault/resource_jwt_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_kmip_secret_backend.go
+++ b/vault/resource_kmip_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"time"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"

--- a/vault/resource_kmip_secret_role.go
+++ b/vault/resource_kmip_secret_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_kmip_secret_scope.go
+++ b/vault/resource_kmip_secret_scope.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/resource_kubernetes_auth_backend_config.go
+++ b/vault/resource_kubernetes_auth_backend_config.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_kubernetes_auth_backend_role.go
+++ b/vault/resource_kubernetes_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_kubernetes_secret_backend.go
+++ b/vault/resource_kubernetes_secret_backend.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_kubernetes_secret_backend_role.go
+++ b/vault/resource_kubernetes_secret_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_kv_secret.go
+++ b/vault/resource_kv_secret.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_kv_secret_backend_v2.go
+++ b/vault/resource_kv_secret_backend_v2.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_kv_secret_v2.go
+++ b/vault/resource_kv_secret_v2.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"time"
 

--- a/vault/resource_ldap_auth_backend.go
+++ b/vault/resource_ldap_auth_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_ldap_auth_backend_group.go
+++ b/vault/resource_ldap_auth_backend_group.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_ldap_auth_backend_user.go
+++ b/vault/resource_ldap_auth_backend_user.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_managed_keys.go
+++ b/vault/resource_managed_keys.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_mfa_duo.go
+++ b/vault/resource_mfa_duo.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_mfa_okta.go
+++ b/vault/resource_mfa_okta.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_mfa_pingid.go
+++ b/vault/resource_mfa_pingid.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_mfa_totp.go
+++ b/vault/resource_mfa_totp.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_mount.go
+++ b/vault/resource_mount.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_namespace.go
+++ b/vault/resource_namespace.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 	"time"

--- a/vault/resource_nomad_secret_backend.go
+++ b/vault/resource_nomad_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/consts"

--- a/vault/resource_nomad_secret_role.go
+++ b/vault/resource_nomad_secret_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_okta_auth_backend.go
+++ b/vault/resource_okta_auth_backend.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strconv"
 	"strings"
 

--- a/vault/resource_okta_auth_backend_group.go
+++ b/vault/resource_okta_auth_backend_group.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_okta_auth_backend_user.go
+++ b/vault/resource_okta_auth_backend_user.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_pki_secret_backend_cert.go
+++ b/vault/resource_pki_secret_backend_cert.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_pki_secret_backend_config_ca.go
+++ b/vault/resource_pki_secret_backend_config_ca.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_pki_secret_backend_config_urls.go
+++ b/vault/resource_pki_secret_backend_config_urls.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_pki_secret_backend_crl_config.go
+++ b/vault/resource_pki_secret_backend_crl_config.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_pki_secret_backend_intermediate_cert_request.go
+++ b/vault/resource_pki_secret_backend_intermediate_cert_request.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"context"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"

--- a/vault/resource_pki_secret_backend_intermediate_set_signed.go
+++ b/vault/resource_pki_secret_backend_intermediate_set_signed.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_pki_secret_backend_role.go
+++ b/vault/resource_pki_secret_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_pki_secret_backend_root_cert.go
+++ b/vault/resource_pki_secret_backend_root_cert.go
@@ -9,7 +9,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"net/http"
 	"strings"
 

--- a/vault/resource_pki_secret_backend_root_sign_intermediate.go
+++ b/vault/resource_pki_secret_backend_root_sign_intermediate.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_pki_secret_backend_sign.go
+++ b/vault/resource_pki_secret_backend_sign.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_policy.go
+++ b/vault/resource_policy.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_quota_lease_count.go
+++ b/vault/resource_quota_lease_count.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vault/resource_quota_rate_limit.go
+++ b/vault/resource_quota_rate_limit.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"

--- a/vault/resource_rabbitmq_secret_backend.go
+++ b/vault/resource_rabbitmq_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_rabbitmq_secret_backend_role.go
+++ b/vault/resource_rabbitmq_secret_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_raft_autopilot.go
+++ b/vault/resource_raft_autopilot.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 

--- a/vault/resource_raft_snapshot_agent_config.go
+++ b/vault/resource_raft_snapshot_agent_config.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-provider-vault/internal/provider"
 	"github.com/hashicorp/terraform-provider-vault/util"

--- a/vault/resource_ssh_secret_backend_ca.go
+++ b/vault/resource_ssh_secret_backend_ca.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_ssh_secret_backend_role.go
+++ b/vault/resource_ssh_secret_backend_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_terraform_cloud_secret_backend.go
+++ b/vault/resource_terraform_cloud_secret_backend.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_terraform_cloud_secret_creds.go
+++ b/vault/resource_terraform_cloud_secret_creds.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_terraform_cloud_secret_role.go
+++ b/vault/resource_terraform_cloud_secret_role.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_token.go
+++ b/vault/resource_token.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 

--- a/vault/resource_token_auth_backend_role.go
+++ b/vault/resource_token_auth_backend_role.go
@@ -6,7 +6,7 @@ package vault
 import (
 	"context"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/resource_transit_cache_config.go
+++ b/vault/resource_transit_cache_config.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/vault/resource_transit_secret_backend_key.go
+++ b/vault/resource_transit_secret_backend_key.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"regexp"
 	"strings"
 

--- a/vault/sentinel.go
+++ b/vault/sentinel.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/vault/api"

--- a/vault/structures.go
+++ b/vault/structures.go
@@ -5,7 +5,7 @@ package vault
 
 import (
 	"encoding/json"
-	"log"
+	log "github.com/sourcegraph-ce/logrus"
 	"strings"
 	"time"
 


### PR DESCRIPTION
stdout: Namespace(repository='github.com/sourcegraph-ce/terraform-provider-vault', batch_change_name='log-provider-go-with-python-script-2', description='This batch change opens a PR for each .go file in a terraform provider repository, and replaces the standard library "log" import statement with the "logrus" library.  This batch change for each repository where the import "log" statement is replaced with "logrus".\n', secret='supersecret', reopen=False)
cmd
testdata
.release
schema
scripts
.github
vault
internal
website
eval
testutil
.git
helper
generated
codegen
util
generate
coverage
workflows
provider
identity
consts
pki
entity
mfa
group
docs
r
guides
d
namespace-enhancements
examples
basic
objects
info
branches
logs
refs
hooks
97
1b
31
08
94
8d
65
20
99
9f
24
eb
6e
18
b6
e2
78
e6
66
b0
49
fe
01
bd
57
89
5a
c5
1e
e4
f5
d0
1c
44
95
72
dc
12
b7
ee
11
c8
22
1f
53
7a
47
5c
7c
07
fa
59
87
81
9e
75
52
8e
d6
96
ba
e3
29
02
f2
ac
3f
71
4a
ec
10
0e
e7
a9
9c
a3
6c
db
ea
ff
bf
dd
76
43
3e
34
60
1d
c9
4c
05
ca
26
06
a4
21
d2
85
19
fd
82
9b
a0
c2
f3
fb
b8
b4
0b
c1
a6
0f
74
93
61
5b
cf
d1
c7
de
2a
f6
e9
pack
f7
ef
9a
8b
e8
da
d7
b3
ce
79
3a
b5
f1
ae
e0
be
28
a2
info
f8
80
e5
ed
a7
3c
9d
1a
15
a5
56
7d
c6
2b
fc
ad
09
2e
d4
4b
50
98
73
6d
27
f0
3b
70
7e
bc
7f
46
88
0c
c0
af
d5
a8
5e
35
16
b1
40
67
aa
ab
8c
3d
41
e1
b9
6b
23
84
00
37
4f
d3
54
0d
33
8f
d9
39
36
55
63
17
77
c4
92
68
f9
c3
04
38
2c
8a
64
b2
7b
48
32
cd
91
6a
14
5d
bb
2d
cc
5f
58
45
f4
03
a1
25
6f
86
62
df
4d
0a
13
30
90
d8
refs
heads
tags
heads
resources
datasources
transform
role
alphabet
transformation
template
transform
encode
decode
templates

[_Created by Sourcegraph batch change `admin/log-provider-go-with-python-script-2`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/log-provider-go-with-python-script-2)